### PR TITLE
Ale video params

### DIFF
--- a/rl4j-examples/src/main/java/org/deeplearning4j/examples/rl4j/A3CALE.java
+++ b/rl4j-examples/src/main/java/org/deeplearning4j/examples/rl4j/A3CALE.java
@@ -73,7 +73,7 @@ public class A3CALE {
         //setup the emulation environment through ALE, you will need a ROM file
         ALEMDP mdp = null;
         try {
-            mdp = new ALEMDP("/home/bam4d/konduit/ALE/ROMS/pong.bin");
+            mdp = new ALEMDP("pong.bin");
         } catch (UnsatisfiedLinkError e) {
             System.out.println("To run this example, uncomment the \"ale-platform\" dependency in the pom.xml file.");
         }

--- a/rl4j-examples/src/main/java/org/deeplearning4j/examples/rl4j/A3CALE.java
+++ b/rl4j-examples/src/main/java/org/deeplearning4j/examples/rl4j/A3CALE.java
@@ -36,11 +36,11 @@ public class A3CALE {
     public static HistoryProcessor.Configuration ALE_HP =
         new HistoryProcessor.Configuration(
             4,       //History length
-            152,      //resize width
-            194,     //resize height
-            152,      //crop width
+            84,      //resize width
+            84,     //resize height
+            160,      //crop width
             194,      //crop height
-            8,       //cropping x offset
+            0,       //cropping x offset
             32,       //cropping y offset
             4       //skip mod (one frame is picked every x
         );

--- a/rl4j-examples/src/main/java/org/deeplearning4j/examples/rl4j/A3CALE.java
+++ b/rl4j-examples/src/main/java/org/deeplearning4j/examples/rl4j/A3CALE.java
@@ -34,16 +34,16 @@ import org.nd4j.linalg.learning.config.Adam;
 public class A3CALE {
 
     public static HistoryProcessor.Configuration ALE_HP =
-            new HistoryProcessor.Configuration(
-                    4,       //History length
-                    84,      //resize width
-                    110,     //resize height
-                    84,      //crop width
-                    84,      //crop height
-                    0,       //cropping x offset
-                    0,       //cropping y offset
-                    4        //skip mod (one frame is picked every x
-            );
+        new HistoryProcessor.Configuration(
+            4,       //History length
+            152,      //resize width
+            194,     //resize height
+            152,      //crop width
+            194,      //crop height
+            8,       //cropping x offset
+            32,       //cropping y offset
+            4       //skip mod (one frame is picked every x
+        );
 
     public static A3CDiscrete.A3CConfiguration ALE_A3C =
             new A3CDiscrete.A3CConfiguration(
@@ -73,7 +73,7 @@ public class A3CALE {
         //setup the emulation environment through ALE, you will need a ROM file
         ALEMDP mdp = null;
         try {
-            mdp = new ALEMDP("pong.bin");
+            mdp = new ALEMDP("/home/bam4d/konduit/ALE/ROMS/pong.bin");
         } catch (UnsatisfiedLinkError e) {
             System.out.println("To run this example, uncomment the \"ale-platform\" dependency in the pom.xml file.");
         }

--- a/rl4j-examples/src/main/java/org/deeplearning4j/examples/rl4j/ALE.java
+++ b/rl4j-examples/src/main/java/org/deeplearning4j/examples/rl4j/ALE.java
@@ -76,7 +76,7 @@ public class ALE {
         //setup the emulation environment through ALE, you will need a ROM file
         ALEMDP mdp = null;
         try {
-            mdp = new ALEMDP("/home/bam4d/konduit/ALE/ROMS/pong.bin");
+            mdp = new ALEMDP("pong.bin");
         } catch (UnsatisfiedLinkError e) {
             System.out.println("To run this example, uncomment the \"ale-platform\" dependency in the pom.xml file.");
         }

--- a/rl4j-examples/src/main/java/org/deeplearning4j/examples/rl4j/ALE.java
+++ b/rl4j-examples/src/main/java/org/deeplearning4j/examples/rl4j/ALE.java
@@ -35,11 +35,11 @@ public class ALE {
     public static HistoryProcessor.Configuration ALE_HP =
         new HistoryProcessor.Configuration(
             4,       //History length
-            152,      //resize width
-            194,     //resize height
-            152,      //crop width
+            84,      //resize width
+            84,     //resize height
+            160,      //crop width
             194,      //crop height
-            8,       //cropping x offset
+            0,       //cropping x offset
             32,       //cropping y offset
             4       //skip mod (one frame is picked every x
         );

--- a/rl4j-examples/src/main/java/org/deeplearning4j/examples/rl4j/ALE.java
+++ b/rl4j-examples/src/main/java/org/deeplearning4j/examples/rl4j/ALE.java
@@ -17,6 +17,7 @@
 package org.deeplearning4j.examples.rl4j;
 
 import java.io.IOException;
+
 import org.deeplearning4j.rl4j.learning.HistoryProcessor;
 import org.deeplearning4j.rl4j.learning.sync.qlearning.QLearning;
 import org.deeplearning4j.rl4j.learning.sync.qlearning.discrete.QLearningDiscreteConv;
@@ -26,47 +27,46 @@ import org.deeplearning4j.rl4j.util.DataManager;
 
 /**
  * @author saudet
- *
+ * <p>
  * Main example for DQN with The Arcade Learning Environment (ALE)
- *
  */
 public class ALE {
 
     public static HistoryProcessor.Configuration ALE_HP =
-            new HistoryProcessor.Configuration(
-                    4,       //History length
-                    84,      //resize width
-                    110,     //resize height
-                    84,      //crop width
-                    84,      //crop height
-                    0,       //cropping x offset
-                    0,       //cropping y offset
-                    4        //skip mod (one frame is picked every x
-            );
+        new HistoryProcessor.Configuration(
+            4,       //History length
+            152,      //resize width
+            194,     //resize height
+            152,      //crop width
+            194,      //crop height
+            8,       //cropping x offset
+            32,       //cropping y offset
+            4       //skip mod (one frame is picked every x
+        );
 
     public static QLearning.QLConfiguration ALE_QL =
-            new QLearning.QLConfiguration(
-                    123,      //Random seed
-                    10000,    //Max step By epoch
-                    8000000,  //Max step
-                    1000000,  //Max size of experience replay
-                    32,       //size of batches
-                    10000,    //target update (hard)
-                    500,      //num step noop warmup
-                    0.1,      //reward scaling
-                    0.99,     //gamma
-                    100.0,    //td-error clipping
-                    0.1f,     //min epsilon
-                    100000,   //num step for eps greedy anneal
-                    true      //double-dqn
-            );
+        new QLearning.QLConfiguration(
+            123,      //Random seed
+            10000,    //Max step By epoch
+            8000000,  //Max step
+            1000000,  //Max size of experience replay
+            32,       //size of batches
+            10000,    //target update (hard)
+            500,      //num step noop warmup
+            0.1,      //reward scaling
+            0.99,     //gamma
+            100.0,    //td-error clipping
+            0.1f,     //min epsilon
+            100000,   //num step for eps greedy anneal
+            true      //double-dqn
+        );
 
     public static DQNFactoryStdConv.Configuration ALE_NET_QL =
-            new DQNFactoryStdConv.Configuration(
-                    0.00025, //learning rate
-                    0.000,   //l2 regularization
-                    null, null
-            );
+        new DQNFactoryStdConv.Configuration(
+            0.00025, //learning rate
+            0.000,   //l2 regularization
+            null, null
+        );
 
     public static void main(String[] args) throws IOException {
 
@@ -76,7 +76,7 @@ public class ALE {
         //setup the emulation environment through ALE, you will need a ROM file
         ALEMDP mdp = null;
         try {
-            mdp = new ALEMDP("pong.bin");
+            mdp = new ALEMDP("/home/bam4d/konduit/ALE/ROMS/pong.bin");
         } catch (UnsatisfiedLinkError e) {
             System.out.println("To run this example, uncomment the \"ale-platform\" dependency in the pom.xml file.");
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current video history parameters for the pong.bin example do not crop/resize to show the right part of the screen to the model during training.

The updated parameters correctly format the image

## How was this patch tested?
The old parameters render the environment like this:
![image](https://user-images.githubusercontent.com/1370765/80002365-72e95f80-84b7-11ea-95f5-50e4060867cc.png)

You can see visually here that the formatting of the image is correct with new parameters
![image](https://user-images.githubusercontent.com/1370765/80002161-361d6880-84b7-11ea-9499-2986ee6da3f7.png)

Please review
https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
